### PR TITLE
Fix[#27]: 데일리 가중치 스케줄러 버그 해결

### DIFF
--- a/app/services/daily_weight_resizer.py
+++ b/app/services/daily_weight_resizer.py
@@ -65,10 +65,8 @@ async def resize_weight(
             countries = meta.get('country', {})
 
             for _, genre_name in genres.items():
-                translated = db_w2v_mapper.translate_genre(genre_name)
-                if translated:
-                    genre_dict[translated] += resized_weight
             for _, actor_name in actors.items():
+                genre_dict[genre_name] += resized_weight
                 actor_dict[actor_name] += resized_weight
             for _, director_name in directors.items():
                 director_dict[director_name] += resized_weight

--- a/app/services/daily_weight_resizer.py
+++ b/app/services/daily_weight_resizer.py
@@ -5,7 +5,6 @@ import time
 import numpy as np
 from collections import defaultdict
 import app
-from app.models import db_w2v_mapper
 from app.repositories.managed_action_log_repository import ManagedActionLogRepository
 from app.services import weight_strategy
 from app.enum.action_type import ActionType

--- a/app/services/daily_weight_resizer.py
+++ b/app/services/daily_weight_resizer.py
@@ -64,13 +64,13 @@ async def resize_weight(
             directors = meta.get('director', {})
             countries = meta.get('country', {})
 
-            for _, genre_name in genres.items():
-            for _, actor_name in actors.items():
+            for _, genre_name in genres:
                 genre_dict[genre_name] += resized_weight
+            for _, actor_name in actors:
                 actor_dict[actor_name] += resized_weight
-            for _, director_name in directors.items():
+            for _, director_name in directors:
                 director_dict[director_name] += resized_weight
-            for _, country_name in countries.items():
+            for _, country_name in countries:
                 country_dict[country_name] += resized_weight
 
         

--- a/app/util/weight_aging.py
+++ b/app/util/weight_aging.py
@@ -7,4 +7,4 @@ def exponential_decay_weight(original_weight: float, event_timestamp_ms: int, la
     delta_days = int(delta_ms / (1000 * 60 * 60 * 24))
 
     decayed_weight = original_weight * math.exp(-lambda_ * delta_days)
-    return round(decayed_weight, 2)
+    return decayed_weight

--- a/app/util/weight_aging.py
+++ b/app/util/weight_aging.py
@@ -4,7 +4,7 @@ import math
 def exponential_decay_weight(original_weight: float, event_timestamp_ms: int, lambda_: float = 0.1) -> float:
     current_timestamp_ms = int(time.time() * 1000)
     delta_ms = current_timestamp_ms - event_timestamp_ms
-    delta_days = delta_ms / (1000 * 60 * 60 * 24)
+    delta_days = int(delta_ms / (1000 * 60 * 60 * 24))
 
     decayed_weight = original_weight * math.exp(-lambda_ * delta_days)
     return round(decayed_weight, 2)


### PR DESCRIPTION
## 확인 사항
- [x] 💯 테스트는 잘 통과했나요?
- [x] 🏗️ 빌드는 성공했나요?
- [x] 🧹 불필요한 코드는 제거했나요?
- [x] 💭 이슈는 등록했나요?
- [x] 🏷️ 라벨은 등록했나요?

## 작업 내용
데일리 가중치 스케줄러 버그를 해결했습니다.
- Action Log 형태 변경으로 인한 참조 오류. list를 dict처럼 참조
- 재계산된 가중치 소수점 제한으로 인한 재계산값 미반영. 0.0으로 반영되는 문제
- 재계산된 가중치 저장 시 metaInfo의 이름이 db 기준이 아닌 model 기준으로 저장되는 문제

## 시퀀스 다이어 그램

## 주의사항

Closes #27 
