### PR TITLE
Fix[#31]: 데일리 가중치 스케줄러와 사용자 가중치 동시 업데이트 시 업데이트 누락 방지

### DIFF
--- a/app/repositories/user_weight_repository.py
+++ b/app/repositories/user_weight_repository.py
@@ -82,8 +82,8 @@ class UserWeightRepository:
         results = await cursor.to_list(length=None)
         return results
 
-    async def update_user_weight(self, user_id: int, meta_info_name: str, diff: float):
-        filter = {"user_id": user_id, "name": meta_info_name}
+    async def update_user_weight(self, user_id: int, meta_info_id: str, diff: float):
+        filter = {"user_id": user_id, "meta_info_id": meta_info_id}
         update = {"$inc": {"weight": diff}}
         await self.collection.update_one(filter, update, upsert=True)
 

--- a/app/repositories/user_weight_repository.py
+++ b/app/repositories/user_weight_repository.py
@@ -1,8 +1,6 @@
 from typing import List, Dict
-from motor.motor_asyncio import AsyncIOMotorClient, AsyncIOMotorCollection
 from pymongo import UpdateOne
-
-from app.models import db_w2v_mapper
+from motor.motor_asyncio import AsyncIOMotorClient, AsyncIOMotorCollection
 
 
 class UserWeightRepository:
@@ -86,9 +84,9 @@ class UserWeightRepository:
         results = await cursor.to_list(length=None)
         return results
 
-    async def reset_weight(self, user_id: int, genre: str, weight: float):
-        filter = {"user_id": user_id, "name": genre}
-        update = {"$set": {"weight": weight}}
+    async def update_user_weight(self, user_id: int, meta_info_name: str, diff: float):
+        filter = {"user_id": user_id, "name": meta_info_name}
+        update = {"$inc": {"weight": diff}}
         await self.collection.update_one(filter, update, upsert=True)
 
     async def decrease_user_weights_from_log(self, log: dict, weight: float):

--- a/app/repositories/user_weight_repository.py
+++ b/app/repositories/user_weight_repository.py
@@ -13,7 +13,6 @@ class UserWeightRepository:
     ):
         operations = []
         for meta_id, name in meta_info:
-            name = db_w2v_mapper.translate_genre(name)
             operations.append(
                 UpdateOne(
                     {"user_id": user_id, "meta_info_id": meta_id},
@@ -34,8 +33,7 @@ class UserWeightRepository:
         operations = []
 
         # 1. 장르
-        for genre in meta_info.get("genres", []):
-            name = db_w2v_mapper.translate_genre(genre)
+        for name in meta_info.get("genres", []):
             operations.append(
                 UpdateOne(
                     {"user_id": user_id, "name": name},
@@ -95,8 +93,7 @@ class UserWeightRepository:
 
         operations = []
 
-        for genre in meta_info.get("genres", []):
-            name = db_w2v_mapper.translate_genre(genre)
+        for name in meta_info.get("genres", []):
             operations.append(
                 UpdateOne(
                     {"user_id": user_id, "name": name},

--- a/app/services/daily_weight_resizer.py
+++ b/app/services/daily_weight_resizer.py
@@ -1,7 +1,5 @@
 import asyncio
 import logging
-import math
-import time
 import numpy as np
 from collections import defaultdict
 import app

--- a/app/services/daily_weight_resizer.py
+++ b/app/services/daily_weight_resizer.py
@@ -136,7 +136,7 @@ async def resize_weight(
         else:
             print(f"💥 보상 트랜잭션 재시도 {error_logs_cnt}개 실패")
     else:
-        print(f"시도할 보상 트랜잭션 없음")
+        print("시도할 보상 트랜잭션 없음")
     print("✅ 가중치 resizing 완료")
     return
 

--- a/app/services/daily_weight_resizer.py
+++ b/app/services/daily_weight_resizer.py
@@ -56,6 +56,7 @@ async def resize_weight(
             weight = weight_strategy.convert_to_weight(action_type, value)
             # 가중치 resize
             resized_weight = exponential_decay_weight(weight, log['timestamp'])
+            diff = resized_weight - weight
 
             meta = log.get('metaInfo', {})
             genres = meta.get('genres', {})
@@ -64,38 +65,38 @@ async def resize_weight(
             countries = meta.get('country', {})
 
             for _, genre_name in genres.items():
-                genre_dict[genre_name] += resized_weight
+                genre_dict[genre_name] += diff
             for _, actor_name in actors.items():
-                actor_dict[actor_name] += resized_weight
+                actor_dict[actor_name] += diff
             for _, director_name in directors.items():
-                director_dict[director_name] += resized_weight
+                director_dict[director_name] += diff
             for _, country_name in countries.items():
-                country_dict[country_name] += resized_weight
+                country_dict[country_name] += diff
 
         
         # MongoDB에 resized 가중치 저장
-        for genre_name, resized_weight in genre_dict.items():
+        for genre_name, diff in genre_dict.items():
             try:
-                await user_weight_repo.reset_weight(user_id, genre_name, resized_weight)
+                await user_weight_repo.update_user_weight(user_id, genre_name, diff)
             except Exception:
                 failed.append((user_id, genre_name, resize_weight))
 
         await asyncio.sleep(5)
-        for actor_name, resized_weight in actor_dict.items():
+        for actor_name, diff in actor_dict.items():
             try:
-                await user_weight_repo.reset_weight(user_id, actor_name, resized_weight)
+                await user_weight_repo.update_user_weight(user_id, actor_name, diff)
             except Exception:
                 failed.append((user_id, actor_name, resize_weight))
 
-        for director_name, resized_weight in director_dict.items():
+        for director_name, diff in director_dict.items():
             try:
-                await user_weight_repo.reset_weight(user_id, director_name, resized_weight)
+                await user_weight_repo.update_user_weight(user_id, director_name, diff)
             except Exception:
                 failed.append((user_id, director_name, resize_weight))
 
-        for country_name, resized_weight in country_dict.items():
+        for country_name, diff in country_dict.items():
             try:
-                await user_weight_repo.reset_weight(user_id, country_name, resized_weight)
+                await user_weight_repo.update_user_weight(user_id, country_name, diff)
             except Exception:
                 failed.append((user_id, country_name, resize_weight))
                 

--- a/app/services/daily_weight_resizer.py
+++ b/app/services/daily_weight_resizer.py
@@ -109,7 +109,7 @@ async def resize_weight(
         for attempt in range(1, MAX_RETRIES + 1):
             try:
                 await redis.save_user_vector(user_id, vector_str)
-                print(f'{LOG_PREFIX} 사용자 {user_id} 벡터 Redis 저장 완료')
+                print(f'사용자 {user_id} 벡터 Redis 저장 완료')
                 break
             except Exception as e:
                 if attempt < MAX_RETRIES:
@@ -130,13 +130,13 @@ async def resize_weight(
                         await gen_warning_log(f"[{attempt}/{MAX_RETRIES}] 보상 트랜잭션 재시도", e)
                     else:
                         error_logs_cnt += 1
-                        await gen_error_log(f"보상트랜잭션 실패, log_id: {log['_id']}", e)
+                        await gen_error_log(f"보상 트랜잭션 실패, log_id: {log['_id']}", e)
         if error_logs_cnt == 0:
             print("✅ 보상 트랜잭션 재시도 성공")
         else:
-            print(f"{LOG_PREFIX} 💥 보상 트랜잭션 재시도 {error_logs_cnt}개 실패")
+            print(f"💥 보상 트랜잭션 재시도 {error_logs_cnt}개 실패")
     else:
-        print(f"{LOG_PREFIX} 시도할 보상 트랜잭션 없음")
+        print(f"시도할 보상 트랜잭션 없음")
     print("✅ 가중치 resizing 완료")
     return
 

--- a/app/services/daily_weight_resizer.py
+++ b/app/services/daily_weight_resizer.py
@@ -48,6 +48,7 @@ async def resize_weight(
         actor_dict = defaultdict(int)
         director_dict = defaultdict(int)
         country_dict = defaultdict(int)
+        genre_name_dict = defaultdict(int) # 벡터 업데이트용
         for log in logs:
             action_type = ActionType[log['action']]
             value = int(log['value'])
@@ -102,7 +103,7 @@ async def resize_weight(
                 failed.append((user_id, country_id, diff))
                 
         # resized 가중치 기반으로 벡터 계산
-        vector = calc_user_vector(genre_dict)
+        vector = calc_user_vector(genre_name_dict)
         vector_str = np.array2string(vector, separator=', ')
 
         for attempt in range(1, MAX_RETRIES + 1):

--- a/app/services/daily_weight_resizer.py
+++ b/app/services/daily_weight_resizer.py
@@ -64,41 +64,42 @@ async def resize_weight(
             directors = meta.get('director', {})
             countries = meta.get('country', {})
 
-            for _, genre_name in genres.items():
-                genre_dict[genre_name] += diff
-            for _, actor_name in actors.items():
-                actor_dict[actor_name] += diff
-            for _, director_name in directors.items():
-                director_dict[director_name] += diff
-            for _, country_name in countries.items():
-                country_dict[country_name] += diff
+            for meta_info_id, genre_name in genres.items():
+                genre_dict[meta_info_id] += diff
+                genre_name_dict[genre_name] += diff
+            for meta_info_id, _ in actors.items():
+                actor_dict[meta_info_id] += diff
+            for meta_info_id, _ in directors.items():
+                director_dict[meta_info_id] += diff
+            for meta_info_id, _ in countries.items():
+                country_dict[meta_info_id] += diff
 
         
         # MongoDB에 resized 가중치 저장
-        for genre_name, diff in genre_dict.items():
+        for genre_id, diff in genre_dict.items():
             try:
-                await user_weight_repo.update_user_weight(user_id, genre_name, diff)
+                await user_weight_repo.update_user_weight(user_id, genre_id, diff)
             except Exception:
-                failed.append((user_id, genre_name, resize_weight))
+                failed.append((user_id, genre_id, diff))
 
         await asyncio.sleep(5)
-        for actor_name, diff in actor_dict.items():
+        for actor_id, diff in actor_dict.items():
             try:
-                await user_weight_repo.update_user_weight(user_id, actor_name, diff)
+                await user_weight_repo.update_user_weight(user_id, actor_id, diff)
             except Exception:
-                failed.append((user_id, actor_name, resize_weight))
+                failed.append((user_id, actor_id, diff))
 
-        for director_name, diff in director_dict.items():
+        for director_id, diff in director_dict.items():
             try:
-                await user_weight_repo.update_user_weight(user_id, director_name, diff)
+                await user_weight_repo.update_user_weight(user_id, director_id, diff)
             except Exception:
-                failed.append((user_id, director_name, resize_weight))
+                failed.append((user_id, director_id, diff))
 
-        for country_name, diff in country_dict.items():
+        for country_id, diff in country_dict.items():
             try:
-                await user_weight_repo.update_user_weight(user_id, country_name, diff)
+                await user_weight_repo.update_user_weight(user_id, country_id, diff)
             except Exception:
-                failed.append((user_id, country_name, resize_weight))
+                failed.append((user_id, country_id, diff))
                 
         # resized 가중치 기반으로 벡터 계산
         vector = calc_user_vector(genre_dict)
@@ -118,10 +119,10 @@ async def resize_weight(
     # 실패 로그 재시도
     error_logs_cnt = 0
     if (len(failed) > 0):
-        for user_id, genre_name, resized_weight in failed:
+        for user_id, meta_info_id, diff in failed:
             for attempt in range(1, MAX_RETRIES + 1):
                 try:
-                    await user_weight_repo.reset_weight(user_id, genre_name, resized_weight)
+                    await user_weight_repo.update_user_weight(user_id, meta_info_id, diff)
                     break
                 except Exception as e:
                     if attempt < MAX_RETRIES:

--- a/app/services/daily_weight_resizer.py
+++ b/app/services/daily_weight_resizer.py
@@ -138,15 +138,6 @@ async def resize_weight(
     print("✅ 가중치 resizing 완료")
     return
 
-
-def calc_resized_weight(timestamp : int, weight : float):
-  current_timestamp_ms = int(time.time() * 1000)
-  delta_ms = current_timestamp_ms - timestamp
-  delta_days = delta_ms / (1000 * 60 * 60 * 24)
-
-  resized_weight = weight * math.exp(-1 * delta_days)
-  return resized_weight
-
 def group_logs_by_user_id(logs: List[Dict]) -> Dict[int, List[Dict]]:
     grouped = defaultdict(list)
     for log in logs:


### PR DESCRIPTION
## 확인 사항
- [x] 💯 테스트는 잘 통과했나요?
- [x] 🏗️ 빌드는 성공했나요?
- [x] 🧹 불필요한 코드는 제거했나요?
- [x] 💭 이슈는 등록했나요?
- [x] 🏷️ 라벨은 등록했나요?

## 작업 내용
데일리 가중치 스케줄러가 사용자 가중치를 업데이트할 때 `$set` 연산자가 아닌 `$inc` 연산자를 사용하게 함으로써 `데일리 가중치 스케줄러 이외의 요청에 의해 사용자 가중치가 업데이트 될 경우 해당 업데이트가 누락되는 문제`를 해결했습니다.

## 시퀀스 다이어 그램

## 주의사항
현재 파악하기론 더 이상 `$set` 연산자를 사용하는 메서드가 없기 때문에 동시성 문제가 발생하지 않을 것으로 예상되지만, DB를 두 개 이상으로 확장할 경우 추가적인 문제가 발생할 수 있습니다. 이 경우 트랜잭션을 사용하는 게 적합하다고 생각합니다만 공식 문서에서는 DB에 저장되는 데이터의 형태를 적절하게 설계하면 트랜잭션 없이도 동시성 문제를 해결할 수 있다고 하며 이를 권고합니다. 이를 권고하는 이유는 MongoDB를 사용하는 이유 자체가 트랜잭션을 최소화하여 시스템의 성능을 높이는 게 목적이기 때문입니다.

Closes #31 
