### PR TITLE
[Refactor]: 데일리 스케줄러 재시도 실패 시 critical 로그 저장

### DIFF
--- a/app/services/daily_weight_resizer.py
+++ b/app/services/daily_weight_resizer.py
@@ -33,7 +33,7 @@ async def resize_weight(
             if attempt < MAX_RETRIES:
                 await asyncio.sleep(RETRY_DELAY_SEC)
             else:
-                await gen_error_log("모든 재시도 실패, 로그 조회 불가", e)
+                await gen_critical_log("모든 재시도 실패, 로그 조회 불가", e)
                 print("💥 가중치 조회 실패")
                 return
 
@@ -78,6 +78,7 @@ async def resize_weight(
         for genre_id, diff in genre_dict.items():
             try:
                 await user_weight_repo.update_user_weight(user_id, genre_id, diff)
+                raise Exception
             except Exception:
                 failed.append((user_id, genre_id, diff))
 
@@ -113,7 +114,7 @@ async def resize_weight(
                 if attempt < MAX_RETRIES:
                     await gen_warning_log(f"[{attempt}/{MAX_RETRIES}] Redis 저장 재시도", e)
                 else:
-                    await gen_error_log(f"사용자 {user_id} 벡터 Redis 저장 실패", e)
+                    await gen_critical_log(f"사용자 {user_id} 벡터 Redis 저장 실패", e)
 
     # 실패 로그 재시도
     error_logs_cnt = 0
@@ -122,13 +123,14 @@ async def resize_weight(
             for attempt in range(1, MAX_RETRIES + 1):
                 try:
                     await user_weight_repo.update_user_weight(user_id, meta_info_id, diff)
+                    raise Exception
                     break
                 except Exception as e:
                     if attempt < MAX_RETRIES:
                         await gen_warning_log(f"[{attempt}/{MAX_RETRIES}] 보상 트랜잭션 재시도", e)
                     else:
                         error_logs_cnt += 1
-                        await gen_error_log(f"보상 트랜잭션 실패, log_id: {log['_id']}", e)
+                        await gen_critical_log(f"보상 트랜잭션 실패, log_id: {log['_id']}", e)
         if error_logs_cnt == 0:
             print("✅ 보상 트랜잭션 재시도 성공")
         else:
@@ -156,11 +158,11 @@ async def remove_managed_action_log():
             if attempt < MAX_RETRIES:
                 await asyncio.sleep(RETRY_DELAY_SEC)
             else:
-                await gen_error_log("모든 재시도 실패, managed_action_log 삭제 불가", e)
+                await gen_critical_log("모든 재시도 실패, managed_action_log 삭제 불가", e)
                 return
             
-async def gen_error_log(message: str, e: Exception):
-    return logger.error(f"{LOG_PREFIX} {message} , error : {e}")
+async def gen_critical_log(message: str, e: Exception):
+    return logger.critical(f"{LOG_PREFIX} {message} , error : {e}")
 
 async def gen_warning_log(message: str, e: Exception):
     return logger.warning(f"{LOG_PREFIX} {message} , error : {e}")

--- a/app/services/daily_weight_resizer.py
+++ b/app/services/daily_weight_resizer.py
@@ -78,7 +78,6 @@ async def resize_weight(
         for genre_id, diff in genre_dict.items():
             try:
                 await user_weight_repo.update_user_weight(user_id, genre_id, diff)
-                raise Exception
             except Exception:
                 failed.append((user_id, genre_id, diff))
 
@@ -123,7 +122,6 @@ async def resize_weight(
             for attempt in range(1, MAX_RETRIES + 1):
                 try:
                     await user_weight_repo.update_user_weight(user_id, meta_info_id, diff)
-                    raise Exception
                     break
                 except Exception as e:
                     if attempt < MAX_RETRIES:


### PR DESCRIPTION
## 확인 사항
- [x] 💯 테스트는 잘 통과했나요?
- [x] 🏗️ 빌드는 성공했나요?
- [x] 🧹 불필요한 코드는 제거했나요?
- [x] 💭 이슈는 등록했나요?
- [x] 🏷️ 라벨은 등록했나요?

## 작업 내용
데일리 스케줄러 재시도 테스트를 진행했습니다.
- 로직 실패 시 3회 재시도 정상 작동 확인
- 재시도 3회 실패 시 로그 저장 -> 기존에 error 로그로 저장되던 것을 critical 로그로 저장되도록 수정


Closes #33 
